### PR TITLE
feat: add ZKEmailSwift podspec for iOS SDK integration

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,4 +1,4 @@
-name: Build MoproFFI
+name: Build ZKEmailSwift
 
 on:
     push:
@@ -29,5 +29,5 @@ jobs:
             - name: Run Package Build
               run: |
                   xcodebuild build \
-                    -scheme MoproFFI \
+                    -scheme ZKEmailSwift \
                     -destination 'generic/platform=iOS'

--- a/Package.swift
+++ b/Package.swift
@@ -4,19 +4,19 @@
 import PackageDescription
 
 let package = Package(
-    name: "MoproFFI",
+    name: "ZKEmailSwift",
     platforms: [
         .macOS(.v10_15),
         .iOS(.v15),
     ],
     products: [
         .library(
-            name: "MoproFFI",
-            targets: ["MoproFFI"]),
+            name: "ZKEmailSwift",
+            targets: ["ZKEmailSwift"]),
     ],
     targets: [
         .target(
-            name: "MoproFFI",
+            name: "ZKEmailSwift",
             dependencies: [
                 .byName(name: "mopro")
             ],
@@ -26,8 +26,8 @@ let package = Package(
             path: "Sources/MoproiOSBindings/MoproBindings.xcframework.zip"
         ),
         .testTarget(
-            name: "MoproFFITests",
-            dependencies: ["MoproFFI"],
+            name: "ZKEmailSwiftTests",
+            dependencies: ["ZKEmailSwift"],
             path: "Tests/",
             resources: [
                 .process("MoproAssets/zkemail_input.json"),

--- a/README.md
+++ b/README.md
@@ -27,17 +27,42 @@ let package = Package(
     ],
     // ...
     targets: [
-        .target(name: "YourSwiftProject", dependencies: ["MoproFFI"])
+        .target(name: "YourSwiftProject", dependencies: ["ZKEmailSwift"])
     ]
 )
 ```
+
+### Option 3: Using CocoaPods
+
+Add the following to your `Podfile`:
+
+```ruby
+platform :ios, '15.0'
+use_frameworks!
+
+target 'YourAppTarget' do
+  pod 'ZKEmailSwift', :git => 'https://github.com/zkmopro/zkemail-swift-package.git', :tag => 'v0.1.0'
+end
+```
+
+Then run:
+```sh
+pod install
+```
+
+Alternatively, if the pod is published to CocoaPods trunk, you can simply add:
+
+```ruby
+pod 'ZKEmailSwift', '~> 0.1.0'
+```
+and run `pod install`.
 
 ## How to Use the Package
 
 ### zkEmail Proofs
 
 ```swift
-import MoproFFI
+import ZKEmailSwift
 
 // Parse your .eml files as inputs
 let inputs: [String: [String]] = [

--- a/Tests/UnitTest.swift
+++ b/Tests/UnitTest.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Foundation
 
-@testable import MoproFFI
+@testable import ZKEmailSwift
 
 struct ZkEmailInputTest: Codable {
     struct Header: Codable {
@@ -25,7 +25,7 @@ struct ZkEmailInputTest: Codable {
     let from_address_sequence: Sequence
 }
 
-class MoproFFITests: XCTestCase {
+class ZKEmailSwiftTests: XCTestCase {
   func testZkEmailProveAndVerify() async throws {
     guard let srsPath = Bundle.module.path(forResource: "srs", ofType: "local") else {
       XCTFail("Failed to find srs.local in test bundle. Ensure it's added to the Tests target.")

--- a/ZKEmailSwift.podspec
+++ b/ZKEmailSwift.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
     #
   
     spec.name         = "ZKEmailSwift"
-    spec.version      = "0.1.0"
+    spec.version      = "0.2.1"
     spec.summary      = "A Swift SDK that wraps ZKEmail bindings for use in iOS apps."
   
     # This description is used to generate tags and improve search results.
@@ -90,8 +90,8 @@ Pod::Spec.new do |spec|
   
     spec.source       = { :git => "https://github.com/zkmopro/zkemail-swift-package.git", :tag => "v#{spec.version}" }
     spec.source       = { :http => "https://zkemail.zkmopro.org/MoproBindings.xcframework.zip"}
-    spec.vendored_frameworks = "Sources/MoproiOSBindings/MoproBindings.xcframework"
-    spec.preserve_paths = "Sources/MoproiOSBindings/MoproBindings.xcframework"
+    spec.vendored_frameworks = "Sources/MoproiOSBindings/MoproBindings.xcframework.zip"
+    spec.preserve_paths = "Sources/MoproiOSBindings/MoproBindings.xcframework.zip"
 
     spec.static_framework = true
 

--- a/ZKEmailSwift.podspec
+++ b/ZKEmailSwift.podspec
@@ -1,0 +1,139 @@
+#
+#  Be sure to run `pod spec lint ZKEmailSwift.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+
+    # ―――  Spec Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  These will help people to find your library, and whilst it
+    #  can feel like a chore to fill in it's definitely to your advantage. The
+    #  summary should be tweet-length, and the description more in depth.
+    #
+  
+    spec.name         = "ZKEmailSwift"
+    spec.version      = "0.1.0"
+    spec.summary      = "A Swift SDK that wraps ZKEmail bindings for use in iOS apps."
+  
+    # This description is used to generate tags and improve search results.
+    #   * Think: What does it do? Why did you write it? What is the focus?
+    #   * Try to keep it short, snappy and to the point.
+    #   * Write the description between the DESC delimiters below.
+    #   * Finally, don't worry about the indent, CocoaPods strips it!
+    spec.description  = <<-DESC
+  Provides a Swift SDK that wraps Mopro bindings for use in iOS applications.
+                    DESC
+    spec.homepage     = "https://zkmopro.org/"
+    # spec.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+  
+  
+    # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  Licensing your code is important. See https://choosealicense.com for more info.
+    #  CocoaPods will detect a license file if there is a named LICENSE*
+    #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+    #
+  
+    spec.license      = { :type => "Apache License, Version 2.0", :file => File.join(__dir__, 'LICENSE') }
+    # spec.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+  
+  
+    # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  Specify the authors of the library, with email addresses. Email addresses
+    #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+    #  accepts just a name if you'd rather not provide an email address.
+    #
+    #  Specify a social_media_url where others can refer to, for example a twitter
+    #  profile URL.
+    #
+  
+    spec.author             = { "mopro" => "hello@zkmopro.org" }
+  
+    # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  If this Pod runs only on iOS or OS X, then specify the platform and
+    #  the deployment target. You can optionally include the target after the platform.
+    #
+  
+    spec.platform     = :ios, "15.0"
+    spec.swift_versions = ['5.0']
+
+    spec.pod_target_xcconfig = {
+        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 x86_64',
+        'ONLY_ACTIVE_ARCH' => 'YES',
+        'SUPPORTS_MACCATALYST' => 'NO'
+    }
+
+    spec.user_target_xcconfig = {
+        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 x86_64',
+        'ONLY_ACTIVE_ARCH' => 'YES'
+    }
+
+    #  When using multiple platforms
+    # spec.ios.deployment_target = "5.0"
+    # spec.osx.deployment_target = "10.7"
+    # spec.watchos.deployment_target = "2.0"
+    # spec.tvos.deployment_target = "9.0"
+    # spec.visionos.deployment_target = "1.0"
+  
+  
+    # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  Specify the location from where the source should be retrieved.
+    #  Supports git, hg, bzr, svn and HTTP.
+    #
+  
+    spec.source       = { :git => "https://github.com/zkmopro/zkemail-swift-package.git", :tag => "v#{spec.version}" }
+    spec.source       = { :http => "https://zkemail.zkmopro.org/MoproBindings.xcframework.zip"}
+    spec.vendored_frameworks = "Sources/MoproiOSBindings/MoproBindings.xcframework"
+    spec.preserve_paths = "Sources/MoproiOSBindings/MoproBindings.xcframework"
+
+    spec.static_framework = true
+
+  
+    # spec.public_header_files = "Classes/**/*.h"
+  
+  
+    # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  A list of resources included with the Pod. These are copied into the
+    #  target bundle with a build phase script. Anything else will be cleaned.
+    #  You can preserve files from being cleaned, please don't preserve
+    #  non-essential files like tests, examples and documentation.
+    #
+  
+    # spec.resource  = "icon.png"
+  
+    # spec.preserve_paths = "FilesToSave", "MoreFilesToSave"
+  
+  
+    # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  Link your library with frameworks, or libraries. Libraries do not include
+    #  the lib prefix of their name.
+    #
+  
+    # spec.framework  = "SomeFramework"
+    # spec.frameworks = "SomeFramework", "AnotherFramework"
+  
+    # spec.library   = "iconv"
+    # spec.libraries = "iconv", "xml2"
+  
+  
+    # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+    #
+    #  If your library depends on compiler flags you can set them in the xcconfig hash
+    #  where they will only apply to your library. If you depend on other Podspecs
+    #  you can include multiple dependencies to ensure it works.
+  
+    # spec.requires_arc = true
+  
+    # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+    # spec.dependency "JSONKit", "~> 1.4"
+  
+  end


### PR DESCRIPTION
lint with
```sh
pod lib lint ZKEmailSwift.podspec \                 
  --skip-tests \
  --skip-import-validation \
  --allow-warnings \
  --verbose
```

publish with
```sh
pod trunk push ZKEmailSwift.podspec --skip-tests \                                             
  --skip-import-validation \
  --allow-warnings \
  --verbose
```